### PR TITLE
Add title and Twitter metadata to head

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,4 @@ title: NoGA
 show_downloads: false
 author:
   name: 'NoGA Team'
-
+  twitter: '@NogaData'

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -2,6 +2,19 @@
 <html lang="{{ site.lang | default: "en-US" }}">
 <!-- Site hosted on github pages, style derived from orderedlist's minimal theme -->
   <head>
+    {% if page.layout == 'post' %}
+        <title>{{ page.title }} - {{ site.title }}</title>
+
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="{{ site.author.twitter }}" />
+        <meta name="twitter:title" content="{{ page.title }}" />
+        <meta name="twitter:description" content="{{ page.excerpt | markdownify }}" />
+        <meta name="twitter:image" content="{{ "/NoGA.jpg" | absolute_url }}" />
+        <meta name="twitter:image:alt" content='"Surveillance" by Jonathan McIntosh' />
+    {% else %}
+        <title>{{ site.title }}</title>
+    {% endif %}
+
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
This PR adds the `title` tag to the head, as well as several `meta` tags in order for our posts to be displayed nicely on our Twitter timeline.

The Twitter cards will look like this:

![Screenshot from 2021-11-30 11-10-36](https://user-images.githubusercontent.com/8657512/144028007-55511002-66e4-45b8-9193-5c8e6bdda429.png)